### PR TITLE
Adjust obstacle spawn intervals

### DIFF
--- a/main.js
+++ b/main.js
@@ -361,8 +361,9 @@ const spawner = {
     }
 
     // nächstes Spawnintervall: leicht zufällig, skaliert mit speed
-    const base = THREE.MathUtils.mapLinear(track.speed, 1.0, 2.5, 1.4, 0.9);
-    spawner.nextIn = THREE.MathUtils.clamp(base + (Math.random()*0.6 - 0.3), 0.75, 1.8);
+    const base = THREE.MathUtils.mapLinear(track.speed, 1.0, 2.5, 2.1, 1.3);
+    const randomOffset = Math.random() * 0.9 - 0.45;
+    spawner.nextIn = THREE.MathUtils.clamp(base + randomOffset, 1.2, 2.6);
   },
   update(dt) {
     this.t += dt;
@@ -371,7 +372,7 @@ const spawner = {
       this.spawn();
     }
   },
-  reset() { this.t = 0; this.nextIn = 1.1; },
+  reset() { this.t = 0; this.nextIn = 1.4; },
 };
 
 /** ========= Utilities ========= */


### PR DESCRIPTION
## Summary
- broaden the obstacle spawn timing formula to allow longer base intervals while retaining track speed scaling
- enlarge the random offset window and raise the clamp minimum to avoid very short spawns
- update the default spawn interval reset value to align with the new timing range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d058f6066c832e97fd65451ce48daa