### PR TITLE
Extend track back extension

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ scene.add(reticle);
 const track = {
   width: 1.8,
   length: 3.0,
-  backExtension: 0.5,
+  backExtension: 1.0,
   treadmill: true,
   speed: 1.5,         // m/s – Bewegung der Hindernisse Richtung Spieler
   laneOffset: 0.6,    // drei "gedachte" Lanes: -0.6, 0, +0.6


### PR DESCRIPTION
## Summary
- extend the AR track back extension to 1 meter to keep the plane and grid behind the player

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d05bab1fa4832ea99b4ab21284b287