### PR TITLE
Extend track back extension to three meters

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ scene.add(reticle);
 const track = {
   width: 1.8,
   length: 3.0,
-  backExtension: 1.0,
+  backExtension: 3.0,
   treadmill: true,
   speed: 1.5,         // m/s – Bewegung der Hindernisse Richtung Spieler
   laneOffset: 0.6,    // drei "gedachte" Lanes: -0.6, 0, +0.6


### PR DESCRIPTION
## Summary
- increase the track configuration's backExtension to 3.0 meters so the surface extends further behind the player

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d05dd26518832eb3dcfa3c0bed0a88